### PR TITLE
ENV keys are strings by default

### DIFF
--- a/lib/env_enforcer.rb
+++ b/lib/env_enforcer.rb
@@ -33,7 +33,7 @@ module EnvEnforcer
     end
 
     def defined_keys
-      ENV.keys.map(&:to_s)
+      ENV.keys
     end
 
     def default_keys


### PR DESCRIPTION
No need to map over them again, is there?
